### PR TITLE
데이터 필터 축제시작일 기준에서 축제 종료일로 변경

### DIFF
--- a/src/js/festival.js
+++ b/src/js/festival.js
@@ -25,7 +25,7 @@ async function fetchFestivalData(apiUrl) {
     const jsonData = xmlToJson(XmlNode);
     const festivalRes = jsonData.response.body.items.item;
     const filteredByTodayData = festivalRes.filter((data)=>{
-      return data.fstvlStartDate > today;
+      return data.fstvlEndDate > today;
     })
 
     return filteredByTodayData;


### PR DESCRIPTION
festival.js 

 오늘 열리고 있는 축제들도 포함하기 위해 데이터 필터 날짜 기준을 
fstvlStartDate에서 fstvlEndDate로 변경했습니다.
